### PR TITLE
Refactor: Replace print statements with logging

### DIFF
--- a/app/api/video.py
+++ b/app/api/video.py
@@ -1,3 +1,4 @@
+import logging
 from fastapi import APIRouter, HTTPException, Body, BackgroundTasks, Request, Header
 from typing import List, Optional, Dict, Annotated
 import uuid
@@ -25,6 +26,7 @@ from app.queue_manager import VideoQueueManager
 
 router = APIRouter()
 queue_manager = VideoQueueManager()
+logger = logging.getLogger(__name__)
 
 PLACEHOLDER_VIDEO_PATH = "static/offline_video.mp4"
 
@@ -75,16 +77,16 @@ async def read_file_chunked(
                 await loop.run_in_executor(None, f.close)
 
     except FileNotFoundError as e_fnf:
-        print(
-            f"Error in read_file_chunked: Placeholder file not found at {file_path}. Error: {e_fnf}"
-        )
+        logger.error(
+            f"Error in read_file_chunked: Placeholder file not found at {file_path}. Error: {e_fnf}",
+            exc_info=True)
         raise RuntimeError(
             f"Streaming failed: file {file_path} not found during read_file_chunked operation."
         ) from e_fnf
     except Exception as e:
-        print(
-            f"Error streaming placeholder file {file_path} during read_file_chunked operation: {e}"
-        )
+        logger.error(
+            f"Error streaming placeholder file {file_path} during read_file_chunked operation: {e}",
+            exc_info=True)
         raise RuntimeError(
             f"Streaming failed for file {file_path} during read_file_chunked operation."
         ) from e
@@ -192,9 +194,9 @@ async def stream_live_video(
                         yield chunk
                         bytes_yielded_for_this_response += len(chunk)
                 except Exception as e_iter_live:
-                    print(
-                        f"Error during /live_stream content iteration for {active_video_url}: {e_iter_live}"
-                    )
+                    logger.error(
+                        f"Error during /live_stream content iteration for {active_video_url}: {e_iter_live}",
+                        exc_info=True)
                 finally:
                     if stream:
                         await stream.close()
@@ -213,9 +215,9 @@ async def stream_live_video(
         except Exception as e_general_setup:
             if stream:
                 await stream.close()
-            print(
-                f"Unexpected error during /live_stream setup for {active_video_url}: {e_general_setup}"
-            )
+            logger.error(
+                f"Unexpected error during /live_stream setup for {active_video_url}: {e_general_setup}",
+                exc_info=True)
             active_video_url = None
 
     if not active_video_url:
@@ -343,9 +345,9 @@ async def stream_video(
                     yield data
                     bytes_yielded += len(data)
             except Exception as e_iter_direct:
-                print(
-                    f"Error in /stream/{video_id} content iterator for {url}: {e_iter_direct}"
-                )
+                logger.error(
+                    f"Error in /stream/{video_id} content iterator for {url}: {e_iter_direct}",
+                    exc_info=True)
             finally:
                 if stream:
                     await stream.close()
@@ -376,9 +378,9 @@ async def stream_video(
     except Exception as e_general_direct:
         if stream:
             await stream.close()
-        print(
-            f"Stream for {video_id}: An unexpected error occurred: {e_general_direct}"
-        )
+        logger.error(
+            f"Stream for {video_id}: An unexpected error occurred: {e_general_direct}",
+            exc_info=True)
         raise HTTPException(
             status_code=500,
             detail=f"An unexpected error occurred while trying to stream {video_id}: {type(e_general_direct).__name__}",

--- a/app/core/ytdlp.py
+++ b/app/core/ytdlp.py
@@ -1,8 +1,11 @@
 import yt_dlp
 import asyncio
+import logging
 from typing import Dict, Any, Optional
 from app.config import YDL_OPTS
 import os
+
+logger = logging.getLogger(__name__)
 
 async def get_video_info(url: str) -> Optional[Dict[str, Any]]:
     """
@@ -41,10 +44,10 @@ async def get_video_info(url: str) -> Optional[Dict[str, Any]]:
             "formats": video_data.get("formats"),
         }
     except yt_dlp.utils.DownloadError as e:
-        print(f"yt-dlp DownloadError: {e}")
+        logger.error(f"yt-dlp DownloadError while fetching info for {url}: {e}", exc_info=True)
         return None
     except Exception as e:
-        print(f"An unexpected error occurred with yt-dlp: {e}")
+        logger.error(f"An unexpected error occurred with yt-dlp while fetching info for {url}: {e}", exc_info=True)
         return None
 
 
@@ -84,20 +87,18 @@ async def download_video(
                 filename = ydl.prepare_filename(entry_info)
 
                 if not os.path.exists(filename):
-                    print(
-                        f"Warning: File '{filename}' not found after supposedly successful download of '{url}'."
-                    )
+                    logger.warning(
+                        f"File '{filename}' not found after supposedly successful download of '{url}'.")
                 return filename
             else:
-                print(
-                    f"yt-dlp download failed with error code: {error_code} for url: {url}"
-                )
+                logger.error(
+                    f"yt-dlp download failed for {url} with error code: {error_code}")
                 return None
     except yt_dlp.utils.DownloadError as e:
-        print(f"yt-dlp DownloadError during download: {e}")
+        logger.error(f"yt-dlp DownloadError during download of {url}: {e}", exc_info=True)
         return None
     except Exception as e:
-        print(f"An unexpected error occurred during yt-dlp download: {e}")
+        logger.error(f"An unexpected error occurred during yt-dlp download of {url}: {e}", exc_info=True)
         return None
 
 
@@ -105,21 +106,21 @@ if __name__ == "__main__":
 
     async def main():
         test_url_info = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-        print(f"Fetching info for: {test_url_info}")
+        logger.info(f"Fetching info for: {test_url_info}")
         info = await get_video_info(test_url_info)
         if info:
-            print(f"Title: {info.get('title')}")
-            print(f"Duration: {info.get('duration')}s")
-            print(f"Uploader: {info.get('uploader')}")
-            print(f"Thumbnail: {info.get('thumbnail')}")
+            logger.info(f"Title: {info.get('title')}")
+            logger.info(f"Duration: {info.get('duration')}s")
+            logger.info(f"Uploader: {info.get('uploader')}")
+            logger.info(f"Thumbnail: {info.get('thumbnail')}")
         else:
-            print("Failed to get video info.")
+            logger.error("Failed to get video info.")
 
-        print("-" * 20)
+        logger.info("-" * 20)
 
         test_url_download_cc = "https://www.youtube.com/watch?v=y_zSBt0A3dY"
 
-        print(f"Attempting to download: {test_url_download_cc}")
+        logger.info(f"Attempting to download: {test_url_download_cc}")
         if not os.path.exists("downloads"):
             os.makedirs("downloads")
 
@@ -127,12 +128,12 @@ if __name__ == "__main__":
             test_url_download_cc, output_path="downloads/%(title)s [%(id)s].%(ext)s"
         )
         if downloaded_file_path:
-            print(f"Video downloaded successfully to: {downloaded_file_path}")
+            logger.info(f"Video downloaded successfully to: {downloaded_file_path}")
             if os.path.exists(downloaded_file_path):
-                print(f"File '{downloaded_file_path}' confirmed to exist.")
+                logger.info(f"File '{downloaded_file_path}' confirmed to exist.")
             else:
-                print(f"File '{downloaded_file_path}' NOT FOUND.")
+                logger.warning(f"File '{downloaded_file_path}' NOT FOUND after download.")
         else:
-            print("Failed to download video.")
+            logger.error("Failed to download video.")
 
     asyncio.run(main())

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,15 @@
+import logging
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from app.api import video
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Stream Control API")
 

--- a/app/queue_manager.py
+++ b/app/queue_manager.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List, Optional, Tuple
 import uuid
 from fastapi import HTTPException, BackgroundTasks
@@ -10,6 +11,8 @@ from app.core.ytdlp import (
 from app.config import YDL_OPTS
 
 
+logger = logging.getLogger(__name__)
+
 class VideoQueueManager:
     def __init__(self):
         self.video_queue_store: Dict[str, VideoInQueue] = {}
@@ -19,16 +22,14 @@ class VideoQueueManager:
     async def _fetch_and_update_metadata_task(
         self, video_id_in_queue: str, original_url: str
     ):
-        print(
-            f"QueueManager: Fetching metadata for {original_url} (ID: {video_id_in_queue})"
-        )
+        logger.info(
+            f"Fetching metadata for {original_url} (ID: {video_id_in_queue})")
         video_data = await get_video_info(original_url)
 
         video_entry = self.video_queue_store.get(video_id_in_queue)
         if not video_entry:
-            print(
-                f"QueueManager: Video ID {video_id_in_queue} not found in store after metadata fetch."
-            )
+            logger.warning(
+                f"Video ID {video_id_in_queue} not found in store after metadata fetch for {original_url}.")
             return
 
         if video_data:
@@ -40,35 +41,32 @@ class VideoQueueManager:
                 "webpage_url", video_entry.original_url
             )
             video_entry.status = "metadata_fetched"
-            print(f"QueueManager: Metadata updated for {video_entry.title}")
+            logger.info(f"Metadata updated for '{video_entry.title}' (ID: {video_id_in_queue})")
         else:
             video_entry.status = "metadata_failed"
             video_entry.error_message = "Failed to fetch video metadata."
-            print(f"QueueManager: Failed to fetch metadata for {original_url}")
+            logger.error(f"Failed to fetch metadata for {original_url} (ID: {video_id_in_queue})")
 
     async def _download_video_task(self, video_id_in_queue: str):
         video_entry = self.video_queue_store.get(video_id_in_queue)
         if not video_entry:
-            print(
-                f"QueueManager: Download task - Video ID {video_id_in_queue} not found."
-            )
+            logger.warning(
+                f"Download task: Video ID {video_id_in_queue} not found in store.")
             return
 
         if video_entry.status == "downloaded":
-            print(f"QueueManager: Video {video_entry.title} already downloaded.")
+            logger.info(f"Video '{video_entry.title}' (ID: {video_id_in_queue}) already downloaded.")
             return
 
         if not video_entry.original_url:
             video_entry.status = "download_failed"
             video_entry.error_message = "Cannot download, original URL is missing."
-            print(
-                f"QueueManager: Cannot download {video_entry.title}, original URL missing."
-            )
+            logger.error(
+                f"Cannot download '{video_entry.title}' (ID: {video_id_in_queue}), original URL missing.")
             return
 
-        print(
-            f"QueueManager: Starting download for {video_entry.title} (ID: {video_id_in_queue})"
-        )
+        logger.info(
+            f"Starting download for '{video_entry.title}' (ID: {video_id_in_queue}) from {video_entry.original_url}")
         video_entry.status = "downloading"
 
         output_template = YDL_OPTS.get(
@@ -82,13 +80,12 @@ class VideoQueueManager:
         if downloaded_path:
             video_entry.downloaded_path = downloaded_path
             video_entry.status = "downloaded"
-            print(
-                f"QueueManager: Successfully downloaded {video_entry.title} to {downloaded_path}"
-            )
+            logger.info(
+                f"Successfully downloaded '{video_entry.title}' (ID: {video_id_in_queue}) to {downloaded_path}")
         else:
             video_entry.status = "download_failed"
             video_entry.error_message = "Failed to download video."
-            print(f"QueueManager: Failed to download {video_entry.title}")
+            logger.error(f"Failed to download '{video_entry.title}' (ID: {video_id_in_queue}) from {video_entry.original_url}")
 
     def add_video(
         self, payload: VideoCreate, background_tasks: BackgroundTasks
@@ -206,13 +203,11 @@ class VideoQueueManager:
                 active_video_url = str(video_entry.original_url)
                 active_video_title = video_entry.title or active_video_title
             else:
-                print(
-                    f"QueueManager: Current video '{video_entry.title}' has error status '{video_entry.status}'."
-                )
+                logger.warning(
+                    f"Current video '{video_entry.title}' (ID: {self.current_video_id_in_queue}) has error status '{video_entry.status}'. Will not use for live stream.")
         else:
-            print(
-                f"QueueManager: Current video entry for ID {self.current_video_id_in_queue} is invalid or has no URL."
-            )
+            logger.warning(
+                f"Current video entry for ID {self.current_video_id_in_queue} is invalid or has no URL. Cannot use for live stream.")
 
         return active_video_url, active_video_title
 
@@ -257,9 +252,8 @@ class VideoQueueManager:
             "download_failed",
             "pending_download",
         ]:
-            print(
-                f"QueueManager: Video '{video_entry.title}' in status '{video_entry.status}' cannot start download directly without status change."
-            )
+            logger.info(
+                f"Video '{video_entry.title}' (ID: {video_id_in_queue}) in status '{video_entry.status}' - will be set to pending_download.")
 
         video_entry.status = "pending_download"
         background_tasks.add_task(self._download_video_task, video_id_in_queue)
@@ -279,10 +273,10 @@ class VideoQueueManager:
             video_entry.error_message = (
                 f"Download cancelled by user from status: {previous_status}"
             )
-            print(
-                f"QueueManager: Download for video '{video_entry.title}' (ID: {video_id_in_queue}) marked as cancelled."
-            )
+            logger.info(
+                f"Download for video '{video_entry.title}' (ID: {video_id_in_queue}) marked as cancelled from status {previous_status}.")
         elif video_entry.status == "downloaded":
+            logger.info(f"Video '{video_entry.title}' (ID: {video_id_in_queue}) is already downloaded, cancel request ignored.")
             pass
         else:
             pass


### PR DESCRIPTION
Replaced all `print()` calls in the application codebase with structured logging using the `logging` module.

- Configured a basic logger in `app/main.py`.
- Introduced module-level loggers in `app/api/video.py`, `app/core/ytdlp.py`, and `app/queue_manager.py`.
- Converted `print` statements to appropriate `logger.info()`, `logger.warning()`, or `logger.error()` calls, including exception information where relevant.